### PR TITLE
Raw overlap coefficients

### DIFF
--- a/prody2/__init__.py
+++ b/prody2/__init__.py
@@ -32,7 +32,7 @@ from pyworkflow import Config
 from .constants import *
 
 
-__version__ = "3.0.3"
+__version__ = "3.0.8"
 _logo = "icon.png"
 _references = ['Zhang2021']
 

--- a/prody2/protocols/protocol_compare.py
+++ b/prody2/protocols/protocol_compare.py
@@ -165,7 +165,10 @@ class ProDyCompare(EMProtocol):
                 else:
                     self.matrix[i-6, 0] = prody.calcRWSIP(mode_ens[0, 6:i+1], mode_ens[1, 6:i+1])
 
-        prody.writeArray(self._getExtraPath('matrix.txt'), self.matrix)
+        pre_dec_len = max([len(str(int(np.max(self.matrix)))), len(str(int(np.min(self.matrix))))])
+        format_str = '%' + str(pre_dec_len + 4) + '.2f'
+
+        prody.writeArray(self._getExtraPath('matrix.txt'), self.matrix, format=format_str)
 
     def createOutputStep(self):
         outputMatrix = EMFile(filename=self._getExtraPath('matrix.txt'))

--- a/prody2/protocols/protocol_compare.py
+++ b/prody2/protocols/protocol_compare.py
@@ -97,6 +97,11 @@ class ProDyCompare(EMProtocol):
                       label='Match modes',
                       help='Elect whether to match modes.')     
 
+        form.addParam('norm', BooleanParam, default=False, 
+                      condition='metric==%d' % NMA_METRIC_OVERLAP,
+                      label='Normalise overlaps',
+                      help='Elect whether to normalise vectors for overlaps or calculate raw dot products.')
+
     # --------------------------- STEPS functions ------------------------------
     def _insertAllSteps(self):
         # Insert processing steps
@@ -143,7 +148,12 @@ class ProDyCompare(EMProtocol):
             mode_ens = [modes1, modes2]
         
         if self.metric == NMA_METRIC_OVERLAP:
-            self.matrix = prody.calcOverlap(mode_ens[0], mode_ens[1], diag=self.diag)
+            if self.norm:
+                self.matrix = prody.calcOverlap(mode_ens[0], mode_ens[1], diag=self.diag)
+            else:
+                # Calculate direct dot product without vector normalisation found in calcOverlap
+                self.matrix = modes1.getEigvecs().T @ modes2.getEigvecs()
+
             if self.matrix.ndim == 1:
                 self.matrix.reshape(-1, 1)
 

--- a/prody2/protocols/protocol_compare.py
+++ b/prody2/protocols/protocol_compare.py
@@ -97,7 +97,7 @@ class ProDyCompare(EMProtocol):
                       label='Match modes',
                       help='Elect whether to match modes.')     
 
-        form.addParam('norm', BooleanParam, default=False, 
+        form.addParam('norm', BooleanParam, default=True, 
                       condition='metric==%d' % NMA_METRIC_OVERLAP,
                       label='Normalise overlaps',
                       help='Elect whether to normalise vectors for overlaps or calculate raw dot products.')

--- a/prody2/protocols/protocol_edit.py
+++ b/prody2/protocols/protocol_edit.py
@@ -140,11 +140,7 @@ class ProDyEdit(ProDyModesBase):
         amap = prody.alignChains(bigger, smaller, match_func=prody.sameChid, pwalign=False)[0]
         
         if self.edit == NMA_SLICE:
-<<<<<<< HEAD
             self.outModes, self.outAtoms = prody.sliceModel(modes, bigger, amap, norm=self.norm)
-=======
-            self.outModes, self.atoms = prody.sliceModel(modes, bigger, amap)
->>>>>>> master
 
         elif self.edit == NMA_REDUCE:
             if from_prody:

--- a/prody2/protocols/protocol_edit.py
+++ b/prody2/protocols/protocol_edit.py
@@ -81,6 +81,11 @@ class ProDyEdit(EMProtocol):
                       pointerClass='AtomStruct',
                       help='Atoms or pseudoatoms to use as new nodes.')   
 
+        form.addParam('norm', BooleanParam, default=True, 
+                      condition='edit==%d' % NMA_SLICE,
+                      label='Normalise sliced vectors',
+                      help='Elect whether to normalise vectors.')
+
     # --------------------------- STEPS functions ------------------------------
     def _insertAllSteps(self):
         # Insert processing steps
@@ -110,7 +115,7 @@ class ProDyEdit(EMProtocol):
         amap = prody.alignChains(bigger, smaller, match_func=prody.sameChid, pwalign=False)[0]
         
         if self.edit == NMA_SLICE:
-            self.outModes, self.outAtoms = prody.sliceModel(modes, bigger, amap)
+            self.outModes, self.outAtoms = prody.sliceModel(modes, bigger, amap, norm=self.norm)
 
         elif self.edit == NMA_REDUCE:
             if from_prody:
@@ -119,7 +124,7 @@ class ProDyEdit(EMProtocol):
                 self.outModes.calcModes(zeros=zeros)
             else:
                 prody.LOGGER.warn('ContinuousFlex modes cannot be reduced at this time. Slicing instead')
-                self.outModes, self.outAtoms = prody.sliceModel(modes, bigger, amap)
+                self.outModes, self.outAtoms = prody.sliceModel(modes, bigger, amap, norm=self.norm)
 
         elif self.edit == NMA_EXTEND:
             self.outModes, self.outAtoms = prody.extendModel(modes, amap, bigger, norm=True)

--- a/prody2/protocols/protocol_edit.py
+++ b/prody2/protocols/protocol_edit.py
@@ -65,8 +65,8 @@ class ProDyEdit(EMProtocol):
                       default=NMA_SLICE,
                       label='Type of edit',
                       help='Modes can have the number of nodes decreased using either eigenvector slicing '
-                      'or Hessian reduction (aka vibrational subsystem analysis; Hinsen et al., Chem Phys 2000; '
-                      'Woodcock et al., J Chem Phys 2008) in the case of modes from ProDy. \n'
+                      'or the slower but often more meaningful Hessian reduction method (aka vibrational subsystem '
+                      'analysis; Hinsen et al., Chem Phys 2000; Woodcock et al., J Chem Phys 2008) for ProDy vectors. \n'
                       'The number of nodes can be increased by extending (copying) eigenvector values '
                       'from nodes of the same residue')
 

--- a/prody2/viewers/viewer_compare.py
+++ b/prody2/viewers/viewer_compare.py
@@ -246,10 +246,11 @@ class ProDyComparisonsViewer(ProtocolViewer):
 
         ax = plotter.figure.gca()
 
-        if self.abs:
-            ax.set_ylim([0, 1])
-        else:
-            ax.set_ylim([-1, 1])
+        if max(matrix) <= 1:
+            if self.abs:
+                ax.set_ylim([0, 1])
+            else:
+                ax.set_ylim([-1, 1])
 
         if cumulOverlap:
             cum_overlaps = np.sqrt(np.power(row, 2).cumsum(axis=row.ndim-1))


### PR DESCRIPTION
This allows us to calculate raw dot products between vectors, rather than just the normalised one. Default is True for normalising.

This can be especially helpful for getting the projection coefficients of normal modes onto a deformation vector. 

It also impacts sliced vector if they haven't been normalised. There is now an option for normalising these too and the default of that is True too.