### PR TITLE
Ensemble test improvement for stable indexing

### DIFF
--- a/prody2/tests/test_prody_pca.py
+++ b/prody2/tests/test_prody_pca.py
@@ -128,10 +128,13 @@ class TestProDy_pca(TestWorkflow):
         # --------------------------------------------------
         # Step 3a. buildPDBEns with index ref -> PCA 2
         # --------------------------------------------------
+
+        ens1 = prody.loadEnsemble(protEns1._getPath("ensemble.ens.npz"))
+        
         protEns2 = self.newProtocol(ProDyBuildPDBEnsemble, refType=1,
                                     matchFunc=0)
         protEns2.structures.set(protSetAS.outputAtomStructs)
-        protEns2.refIndex.set(4)
+        protEns2.refIndex.set(ens1.getLabels().index("3o21_atoms")+1)
         protEns2.setObjLabel('buildPDBEns_ref_idx_4')
         self.launchProtocol(protEns2)   
 

--- a/prody2/tests/test_prody_pca.py
+++ b/prody2/tests/test_prody_pca.py
@@ -130,12 +130,13 @@ class TestProDy_pca(TestWorkflow):
         # --------------------------------------------------
 
         ens1 = prody.loadEnsemble(protEns1._getPath("ensemble.ens.npz"))
+        idx = ens1.getLabels().index("3o21_atoms") + 1
         
         protEns2 = self.newProtocol(ProDyBuildPDBEnsemble, refType=1,
                                     matchFunc=0)
         protEns2.structures.set(protSetAS.outputAtomStructs)
-        protEns2.refIndex.set(ens1.getLabels().index("3o21_atoms")+1)
-        protEns2.setObjLabel('buildPDBEns_ref_idx_4')
+        protEns2.refIndex.set(idx)
+        protEns2.setObjLabel('buildPDBEns_ref_idx_{0}'.format(idx))
         self.launchProtocol(protEns2)   
 
         protPca2 = self.newProtocol(ProDyPCA, numberOfModes=3)
@@ -167,7 +168,7 @@ class TestProDy_pca(TestWorkflow):
         self.launchProtocol(protProj1)   
 
         protProj2 = self.newProtocol(ProDyProject,
-                                      byFrame=True)
+                                     byFrame=True)
         protProj2.inputEnsemble.set(protEns2.outputNpz)
         protProj2.inputModes.set(protPca2.outputModes)
         protProj2.numModes.set(TWO)
@@ -175,7 +176,7 @@ class TestProDy_pca(TestWorkflow):
         self.launchProtocol(protProj2)   
 
         protProj3 = self.newProtocol(ProDyProject,
-                                      byFrame=True)
+                                     byFrame=True)
         protProj3.inputEnsemble.set(protEns2.outputNpz)
         protProj3.inputModes.set(protPca2.outputModes)
         protProj3.numModes.set(THREE)

--- a/prody2/tests/test_prody_pca.py
+++ b/prody2/tests/test_prody_pca.py
@@ -141,7 +141,7 @@ class TestProDy_pca(TestWorkflow):
 
         protPca2 = self.newProtocol(ProDyPCA, numberOfModes=3)
         protPca2.inputEnsemble.set(protEns2.outputNpz)
-        protPca2.setObjLabel('PCA_ref_idx_4')
+        protPca2.setObjLabel('PCA_ref_idx')
         self.launchProtocol(protPca2)  
 
         # ------------------------------------------------


### PR DESCRIPTION
The order in the set of atomic structures is read from the previously built ensemble that used it in order to get the index for testing the reference assignment by index. 