### PR TITLE
Handle interpolate for release

### DIFF
--- a/prody2/protocols/protocol_edit.py
+++ b/prody2/protocols/protocol_edit.py
@@ -42,6 +42,11 @@ from pyworkflow.protocol.params import (PointerParam, EnumParam, BooleanParam,
 
 import prody
 from prody.utilities import ZERO
+try:
+    from prody import interpolateModel
+    have_interp = True
+except:
+    have_interp = False
 
 from prody2.protocols.protocol_modes_base import ProDyModesBase
 
@@ -65,14 +70,25 @@ class ProDyEdit(ProDyModesBase):
         # You need a params to belong to a section:
         form.addSection(label='ProDy edit')
 
-        form.addParam('edit', EnumParam, choices=['Slice', 'Reduce', 'Extend', 'Interpolate'],
-                      default=NMA_SLICE,
-                      label='Type of edit',
-                      help='Modes can have the number of nodes decreased using either eigenvector slicing '
-                      'or the slower but often more meaningful Hessian reduction method (aka vibrational subsystem '
-                      'analysis; Hinsen et al., Chem Phys 2000; Woodcock et al., J Chem Phys 2008) for ProDy vectors. \n'
-                      'The number of nodes can be increased by extending (copying) eigenvector values '
-                      'from nodes of the same residue or by through-space thin plate splines interpolation')
+        if have_interp:
+            form.addParam('edit', EnumParam, choices=['Slice', 'Reduce', 'Extend', 'Interpolate'],
+                        default=NMA_SLICE,
+                        label='Type of edit',
+                        help='Modes can have the number of nodes decreased using either eigenvector slicing '
+                        'or the slower but often more meaningful Hessian reduction method (aka vibrational subsystem '
+                        'analysis; Hinsen et al., Chem Phys 2000; Woodcock et al., J Chem Phys 2008) for ProDy vectors. \n'
+                        'The number of nodes can be increased by extending (copying) eigenvector values '
+                        'from nodes of the same residue or by through-space thin plate splines interpolation')
+        else:
+            form.addParam('edit', EnumParam, choices=['Slice', 'Reduce', 'Extend'],
+                        default=NMA_SLICE,
+                        label='Type of edit',
+                        help='Modes can have the number of nodes decreased using either eigenvector slicing '
+                        'or the slower but often more meaningful Hessian reduction method (aka vibrational subsystem '
+                        'analysis; Hinsen et al., Chem Phys 2000; Woodcock et al., J Chem Phys 2008) for ProDy vectors. \n'
+                        'The number of nodes can be increased by extending (copying) eigenvector values '
+                        'from nodes of the same residue')
+
 
         form.addParam('modes', PointerParam, label='Input SetOfNormalModes',
                       pointerClass='SetOfNormalModes',
@@ -152,7 +168,7 @@ class ProDyEdit(ProDyModesBase):
         elif self.edit == NMA_EXTEND:
             self.outModes, self.atoms = prody.extendModel(modes, amap, bigger, norm=True)
 
-        else:
+        elif have_interp:
             self.outModes, self.atoms = prody.interpolateModel(modes, amap, bigger, norm=True)
 
         prody.writePDB(self._getPath('atoms.pdb'), self.atoms)

--- a/prody2/tests/test_prody_core.py
+++ b/prody2/tests/test_prody_core.py
@@ -37,6 +37,11 @@ from prody2.protocols.protocol_rtb import BLOCKS_FROM_RES, BLOCKS_FROM_SECSTR
 from prody2.protocols.protocol_import import NMD, modes_NPZ, SCIPION, GROMACS
 
 import prody
+try:
+    from prody import interpolateModel
+    have_interp = True
+except:
+    have_interp = False
 
 class TestProDy_core(TestWorkflow):
     """ Test protocol for ProDy Normal Mode Analysis and Deformation Analysis. """
@@ -136,22 +141,23 @@ class TestProDy_core(TestWorkflow):
         protComp3.setObjLabel('Compare_AA_to_extCA')
         self.launchProtocol(protComp3)           
 
-        # ------------------------------------------------
-        # Step 6. Interpolate -> Compare
-        # ------------------------------------------------
-        # Interpolate CA NMA to all-atoms
-        protEdit4 = self.newProtocol(ProDyEdit, edit=NMA_INTERP)
-        protEdit4.modes.set(protANM2.outputModes)
-        protEdit4.newNodes.set(protSel1.outputStructure)
-        protEdit4.setObjLabel('Interp_to_AA')
-        self.launchProtocol(protEdit4)        
+        if have_interp:
+            # ------------------------------------------------
+            # Step 6. Interpolate -> Compare
+            # ------------------------------------------------
+            # Interpolate CA NMA to all-atoms
+            protEdit4 = self.newProtocol(ProDyEdit, edit=NMA_INTERP)
+            protEdit4.modes.set(protANM2.outputModes)
+            protEdit4.newNodes.set(protSel1.outputStructure)
+            protEdit4.setObjLabel('Interp_to_AA')
+            self.launchProtocol(protEdit4)        
 
-        # Compare original AA ANM NMA and interpolated CA ANM NMA
-        protComp4 = self.newProtocol(ProDyCompare)
-        protComp4.modes1.set(protANM1.outputModes)
-        protComp4.modes2.set(protEdit4.outputModes)
-        protComp4.setObjLabel('Compare_AA_to_intCA')
-        self.launchProtocol(protComp4)
+            # Compare original AA ANM NMA and interpolated CA ANM NMA
+            protComp4 = self.newProtocol(ProDyCompare)
+            protComp4.modes1.set(protANM1.outputModes)
+            protComp4.modes2.set(protEdit4.outputModes)
+            protComp4.setObjLabel('Compare_AA_to_intCA')
+            self.launchProtocol(protComp4)
 
         # ------------------------------------------------
         # Step 7. Import other Pdb -> Select chain A and CA


### PR DESCRIPTION
The released version 2.2.0 of ProDy doesn't have interpolateModel because it is still under development, but it is in the branch called scipion that is used for github install. 

We now have a try/except block in the plugin to include the interpolate option if the function is there and the tests do something similar for testing it. 